### PR TITLE
names, concepts, and more

### DIFF
--- a/lib/hlclock.ex
+++ b/lib/hlclock.ex
@@ -101,5 +101,8 @@ defmodule HLClock do
   """
   def default_time(), do: System.os_time(:milliseconds)
 
-  defp max_drift(), do: Application.get_env(:hlclock, :max_drift_millis, 300_000)
+  @doc """
+  Configurable clock synchronization parameter, ε.
+  """
+  def max_drift(), do: Application.get_env(:hlclock, :max_drift_millis, 300_000)
 end

--- a/lib/hlclock.ex
+++ b/lib/hlclock.ex
@@ -1,50 +1,104 @@
 defmodule HLClock do
   @moduledoc """
-  Documentation for HLClock.
+
+  Hybrid Logical Clock
+
+  Provides globally-unique, monotonic timestamps. Timestamps are bounded by the
+  clock synchronization constraint, max_drift.
+
+  Implementation assumes that timestamps are (at a minimum) regularly sent; a
+  clock at rest will eventually be unable to generate timestamps due to assumed
+  bounds on the logical clock relative to physical time.
+
+  In order to account for physical time drift within the system, timestamps
+  should regularly be exchanged between nodes. Generate a timestamp at one node
+  via HLClock.send_timestamp/1; at the other node, call HLClock.recv_timestamp/2
+  with the received timestamp from the first node.
+
+  Inspired by https://www.cse.buffalo.edu/tech-reports/2014-04.pdf
   """
 
+  alias __MODULE__, as: Clock
   alias HLClock.Timestamp
 
-  def new(pt \\ default_clock()) do
-    Timestamp.new(pt, 0)
-  end
+  defstruct [:clock_fn, :curr_ts]
 
-  def now(clock, pt \\ default_clock()) do
-    if Timestamp.ahead?(clock, pt) do
-      Timestamp.increment(clock)
-    else
-      Timestamp.new(pt, 0)
+  @doc """
+  clock constructor requires the node_id, a millisecond clock fn and a
+  maximum drift parameter in milliseconds
+  """
+  def new(node_id \\ 0,
+    clock_fn \\ &Clock.default_time/0) do
+    with {:ok, t0} <- Timestamp.new(clock_fn.(), 0, node_id) do
+      %Clock{clock_fn: clock_fn,
+             curr_ts: t0}
     end
   end
 
-  def less?(clock1, clock2) do
-    Timestamp.compare(clock1, clock2) == :lt
-  end
+  @doc "generate a new timestamp"
+  def send_timestamp(%Clock{curr_ts: old, clock_fn: cfn} = clock) do
+    pt = cfn.()
+    nt = max(old.time, pt)
+    nc = advance(old, nt)
 
-  def update(local, foreign, pt \\ default_clock()) do
-    max_pt = max(pt, max(local.time, foreign.time))
     cond do
-      max_pt == local.time && max_pt == foreign.time ->
-        max_logical = max(local.logical, foreign.logical) + 1
-        Timestamp.new(max_pt, max_logical)
-      foreign.time > local.time && remote_drifted?(foreign, pt) ->
-        local
-      max_pt == local.time ->
-        Timestamp.new(max_pt, local.logical+1)
-      max_pt == foreign.time ->
-        Timestamp.new(max_pt, foreign.logical+1)
+      drift?(clock, nt, pt) ->
+        {:error, :clock_drift_violation}
       true ->
-        Timestamp.new(max_pt, 0)
+        # counter overflow is handled by Timestamp.new
+        with {:ok, new_ts} <- Timestamp.new(nt, nc, old.node_id) do
+          {:ok, %Clock{clock | curr_ts: new_ts}}
+        end
     end
   end
 
-  defp default_clock do
-    System.os_time()
+  defp advance(old, new_time) do
+    cond do
+      old.time == new_time ->
+        old.counter + 1
+      true ->
+        0
+    end
   end
 
-  defp remote_drifted?(foreign, pt) do
-    foreign.time - pt > max_drift()
+  @doc "receive a remote timestamp and merge with local"
+  def recv_timestamp(%Clock{clock_fn: cfn, curr_ts: local} = clock, msg) do
+    pt = cfn.()
+    max_pt = max(pt, max(msg.time, local.time))
+    cond do
+      local.node_id == msg.node_id ->
+        {:error, :duplicate_node_id}
+      drift?(msg.time, pt) ->
+        {:error, :remote_drift_violation}
+      drift?(max_pt, pt) ->
+        {:error, :clock_drift_violation}
+      true ->
+        new_log = merge_logical(max_pt, local, msg)
+        with {:ok, t} <- Timestamp.new(max_pt, new_log, local.node_id) do
+          {:ok, %Clock{clock | curr_ts: t}}
+        end
+    end
   end
 
-  defp max_drift(), do: Application.get_env(:hlclock, :max_drift_millis, 1_000)
+  defp drift?(l, pt) do
+    abs(l - pt) > max_drift()
+  end
+
+  defp merge_logical(max_pt, local, msg) do
+    cond do
+      max_pt == local.time && max_pt == msg.time ->
+        max(local.counter, msg.counter) + 1
+      max_pt == local.time ->
+        local.counter + 1
+      max_pt == msg.time ->
+        msg.counter + 1
+      true ->
+        0
+    end
+  end
+
+  @doc "os_time in milliseconds"
+  def default_time(), do: System.os_time(:milliseconds)
+
+  defp max_drift(), do: Application.get_env(:hlclock, :max_drift_millis, 300_000)
 end

--- a/lib/hlclock/timestamp.ex
+++ b/lib/hlclock/timestamp.ex
@@ -1,6 +1,10 @@
 defmodule HLClock.Timestamp do
   @moduledoc """
-  HULC == Hybrid Unique Logical Clock
+  HLC Timestamp
+
+  Implements the necessary components of the HLC tuple (i.e. logical time and
+  logical counter) with extension to support node ids to provide unique
+  timestamps even in cases where time and counter are the same
 
   Binary representations assume big endianness for interop simplicity with other
   languages/representations.
@@ -11,6 +15,10 @@ defmodule HLClock.Timestamp do
 
   alias __MODULE__, as: T
 
+  @doc """
+  Construct a timestamp from its principal components: logical time (initially
+  node's physical time), logical counter (initally zero), and the node id
+  """
   def new(time, counter, node_id \\ 0) do
     cond do
       byte_size(:binary.encode_unsigned(counter)) > 2 ->
@@ -22,7 +30,10 @@ defmodule HLClock.Timestamp do
     end
   end
 
-  @doc "timestamp comparison"
+  @doc """
+  Exhaustive comparison of two timestamps: precedence is in order of time
+  component, logical counter, and finally node identifier
+  """
   def compare(%{time: t1}, %{time: t2}) when t1 > t2, do: :gt
   def compare(%{time: t1}, %{time: t2}) when t1 < t2, do: :lt
   def compare(%{counter: c1}, %{counter: c2}) when c1 > c2, do: :gt
@@ -35,12 +46,16 @@ defmodule HLClock.Timestamp do
     compare(t1, t2) == :lt
   end
 
-  @doc "to binary representation"
+  @doc """
+  pack the rich Timestamp struct as a 128 bit byte array
+  """
   def encode(%{time: t, counter: c, node_id: n}) do
     << t :: size(48) >> <> << c :: size(16) >> <> << n :: size(64) >>
   end
 
-  @doc "construct a Timestamp from the binary representation"
+  @doc """
+  construct a Timestamp from the binary representation
+  """
   def decode(<<t :: size(48)>> <> <<c::size(16)>> <> <<n::size(64)>>) do
     %T{time: t, counter: c, node_id: n}
   end

--- a/lib/hlclock/timestamp.ex
+++ b/lib/hlclock/timestamp.ex
@@ -31,6 +31,10 @@ defmodule HLClock.Timestamp do
   def compare(%{node_id: n1}, %{node_id: n2}) when n1 < n2, do: :lt
   def compare(_ = %{}, _ = %{}), do: :eq
 
+  def less?(t1, t2) do
+    compare(t1, t2) == :lt
+  end
+
   @doc "to binary representation"
   def encode(%{time: t, counter: c, node_id: n}) do
     << t :: size(48) >> <> << c :: size(16) >> <> << n :: size(64) >>

--- a/lib/hlclock/timestamp.ex
+++ b/lib/hlclock/timestamp.ex
@@ -1,54 +1,49 @@
 defmodule HLClock.Timestamp do
-  defstruct [:time, :logical, node_id: ""]
+  @moduledoc """
+  HULC == Hybrid Unique Logical Clock
+
+  Binary representations assume big endianness for interop simplicity with other
+  languages/representations.
+
+  """
+
+  defstruct [:time, :counter, :node_id]
 
   alias __MODULE__, as: T
 
-  def new(time, logical), do: %T{time: time, logical: logical}
-
-  def new(time, logical, node_id) do
-    with :ok <- validate(time, logical, node_id) do
-      %__MODULE__{time: time, logical: logical, node_id: node_id}
-    end
-  end
-
-  def validate(_, logical, _) do
+  def new(time, counter, node_id \\ 0) do
     cond do
-      byte_size(:binary.encode_unsigned(logical)) > 2 ->
-        {:error, :logical_too_large}
+      byte_size(:binary.encode_unsigned(counter)) > 2 ->
+        {:error, :counter_too_large}
+      byte_size(:binary.encode_unsigned(node_id)) > 8 ->
+        {:error, :node_id_too_large}
       true ->
-        :ok
+        {:ok, %T{time: time, counter: counter, node_id: node_id}}
     end
   end
 
-  def increment(%T{logical: l, time: time}) do
-    %T{time: time, logical: l+1}
+  @doc "timestamp comparison"
+  def compare(%{time: t1}, %{time: t2}) when t1 > t2, do: :gt
+  def compare(%{time: t1}, %{time: t2}) when t1 < t2, do: :lt
+  def compare(%{counter: c1}, %{counter: c2}) when c1 > c2, do: :gt
+  def compare(%{counter: c1}, %{counter: c2}) when c1 < c2, do: :lt
+  def compare(%{node_id: n1}, %{node_id: n2}) when n1 > n2, do: :gt
+  def compare(%{node_id: n1}, %{node_id: n2}) when n1 < n2, do: :lt
+  def compare(_ = %{}, _ = %{}), do: :eq
+
+  @doc "to binary representation"
+  def encode(%{time: t, counter: c, node_id: n}) do
+    << t :: size(48) >> <> << c :: size(16) >> <> << n :: size(64) >>
   end
 
-  def ahead?(clock, physical_time) do
-    clock.time >= physical_time
+  @doc "construct a Timestamp from the binary representation"
+  def decode(<<t :: size(48)>> <> <<c::size(16)>> <> <<n::size(64)>>) do
+    %T{time: t, counter: c, node_id: n}
   end
-
-  def compare(%{time: m1}, %{time: m2}) when m1 > m2, do: :gt
-  def compare(%{time: m1}, %{time: m2}) when m1 < m2, do: :lt
-  def compare(clock1, clock2) do
-    cond do
-      clock1.logical > clock2.logical -> :gt
-      clock1.logical < clock2.logical -> :lt
-      true -> :eq
-    end
-  end
-
-  def encode(%{time: m, logical: c, node_id: n}), do:
-     << m :: size(48) >>
-  <> << c :: size(16) >>
-  <> << n :: size(64) >>
-
-  def decode(<<m :: size(48)>> <> <<c::size(16)>> <> <<n::size(64)>>), do:
-    new(m, c, n)
 
   defimpl String.Chars do
-    def to_string(%{time: time, logical: logical, node_id: node_id}) do
-      "time: #{time}, logical: #{logical}, node_id: #{node_id}"
+    def to_string(%{time: time, counter: counter, node_id: node_id}) do
+      "time: #{time}, counter: #{counter}, node_id: #{node_id}"
     end
   end
 end


### PR DESCRIPTION
For code organization and optimization, I'm sure you can help me out. I haven't looked at the tests yet either, so I probably destroyed those. I'll circle back to testing tomorrow or Monday. Instead, I did the following:

1. Renamed now, update. This was mostly because I was working directly against the paper on my version and just brought a lot of it over wholesale (now and update are fine with me if you prefer).
2. Lifted node_id as a parameter of interest in construction, `Timestamp.new/0`, and in messaging, `HLClock.recv_timestamp/2`, and in comparison.
3. According to the paper, HLCs are bounded on both sides by ϵ. This means that it is entirely possible that your sends could also fail. For example, you could see a timestamp in the "near future," and your physical time doesn't catch up because NTP is not running. Drift could accumulate in this case. This should probably be the kind of failure that propagates up, but we'll worry about that when we get to `GenServer` and whatnot.
4. Renamed logical to counter. This was mostly easier to read relative to the paper as `l` denotes the logical clock which is separate from the counter, `c`. Again, I'm not 100% attached to it; it was just easier to work against the paper.

*NOTE:* compare could probably be simplified given `Timestamp.encode/1`. As the relative ordering of time, counter, and node_id is baked into how a timestamp is packed. I don't know about the performance though. Thoughts?