### PR TITLE
helper utils for interaction with timestamps

### DIFF
--- a/test/hlclock_test.exs
+++ b/test/hlclock_test.exs
@@ -28,4 +28,22 @@ defmodule HLClockTest do
       assert new_clock.counter == 0
     end
   end
+
+  describe "to_datetime/1" do
+    test "returns valid DateTime objects" do
+      fixed_time = System.os_time(:milliseconds)
+      {:ok, clock} = HLClock.Timestamp.new(fixed_time, 0, 0)
+      assert :eq == clock
+      |> HLClock.to_datetime
+      |> DateTime.compare(DateTime.from_unix!(fixed_time, :millisecond))
+    end
+  end
+
+  describe "to_os_time/1" do
+    test "returns time" do
+      {:ok, _hlc} = HLClock.start_link()
+      {:ok, clock} = HLClock.now()
+      assert clock.time == HLClock.to_os_time(clock)
+    end
+  end
 end


### PR DESCRIPTION
The tests aren't particularly imaginative, but we have more comprehensive testing on the actual timestamp and receive logic.

I decided to thoroughly document the `to_datetime` function since it has great utility (possibly as part of an inspection implementation?).